### PR TITLE
Fix: "wine: Unimplemented function ucrtbase.dll.crealf called at address ..."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM jackmckew/pyinstaller-windows
 
+#extra winetrick step to fix "Unimplemented function ucrtbase.dll.crealf called"
+RUN apt-get install -y xvfb libgnutls30 libgnutls30:i386
+RUN xvfb-run winetricks --force -q vcrun2019
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
This fix is based on this thread [https://forum.winehq.org/viewtopic.php?t=40355](https://forum.winehq.org/viewtopic.php?t=40355) which describes the same issue I ran into running this action.

This fix should probably be implemented in a build Docker image.

> Added extra winetricks step to install the Visual C++ Redistributable 2019 package to fix "wine: Unimplemented function ucrtbase.dll.crealf called at address ..." error